### PR TITLE
test/{check-execute-pddl.test, execute-pddl.test.xml}: add test code to check execute-pddl.launch

### DIFF
--- a/task_compiler/CMakeLists.txt
+++ b/task_compiler/CMakeLists.txt
@@ -12,7 +12,9 @@ catkin_package(
 
 if(CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(test/execute-pddl.test.xml)
+  if($ENV{ROS_DISTRO} STREQUAL "indigo") # smach_viewer only available on indigo (https://github.com/jbohren/executive_smach_visualization-release/issues/1)
+    roslaunch_add_file_check(test/execute-pddl.test.xml)
+  endif()
 endif()
 
 install(DIRECTORY launch euslisp samples

--- a/task_compiler/CMakeLists.txt
+++ b/task_compiler/CMakeLists.txt
@@ -10,6 +10,11 @@ catkin_package(
     LIBRARIES # TODO
 )
 
+if(CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(test/execute-pddl.test.xml)
+endif()
+
 install(DIRECTORY launch euslisp samples
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
         USE_SOURCE_PERMISSIONS)

--- a/task_compiler/package.xml
+++ b/task_compiler/package.xml
@@ -20,6 +20,7 @@
 
   <run_depend>pddl_planner</run_depend>
   <run_depend>roseus_smach</run_depend>
+  <run_depend>smach_viewer</run_depend>
 
   <test_depend>rostest</test_depend>
   <!-- <test_depend>pddl_planner</test_depend> -->

--- a/task_compiler/package.xml
+++ b/task_compiler/package.xml
@@ -21,6 +21,7 @@
   <run_depend>pddl_planner</run_depend>
   <run_depend>roseus_smach</run_depend>
 
+  <test_depend>rostest</test_depend>
   <!-- <test_depend>pddl_planner</test_depend> -->
   <!-- <test_depend>roseus_smach</test_depend> -->
 

--- a/task_compiler/test/execute-pddl.test.xml
+++ b/task_compiler/test/execute-pddl.test.xml
@@ -1,0 +1,8 @@
+<launch>
+  <include file="$(find task_compiler)/launch/execute-pddl.launch">
+    <arg name="action" value="null"/>
+    <arg name="description" value="null"/>
+    <arg name="planner_option" value="null"/>
+  </include>
+</launch>
+


### PR DESCRIPTION
to check missing dependency to run execute-pddl.launch.
See https://github.com/jsk-ros-pkg/jsk_demos/issues/1117