### PR TITLE
execute-pddd.launch: remove require from tc_core

### DIFF
--- a/task_compiler/launch/execute-pddl.launch
+++ b/task_compiler/launch/execute-pddl.launch
@@ -18,7 +18,7 @@
         if="$(arg gui)" />
   <node name="tc_core"
         pkg="task_compiler" type="execute-pddl.l"
-        output="screen" required="true">
+        output="screen" >
     <rosparam subst_value="true">
       action_file: $(arg action)
       description_file: $(arg description)


### PR DESCRIPTION
require tag is used to stop demo program (ex. https://github.com/jsk-ros-pkg/jsk_demos/blob/0.0.3/detect_cans_in_fridge_201202/launch/planner.launch), when demo is finished.
If we need such feature, we should add in demo side.
Cc: @furushchev