### PR TITLE
pddl_planner: pddl.py: remove (REACH-GOAL) on action which emerges occasionally

### DIFF
--- a/pddl/pddl_planner/src/pddl.py
+++ b/pddl/pddl_planner/src/pddl.py
@@ -71,6 +71,7 @@ class PDDLPlannerActionServer(object):
                        for y in [re.search("\([^\)]+\)", x)
                                  for x in step_before_after[1].split("Total cost")[0].split("\n")[1:]]
                        if y != None]
+            results = filter(lambda a: a.find("(REACH-GOAL)") < 0, results)
             rospy.loginfo("result => %s" % results)
             return results
         else:


### PR DESCRIPTION
When solving plan with `FFHA` planner, a solution from planner sometimes includes `REACH-GOAL` action which is not defined in the description. (NOT always)
Using `task_compiler`, it can cause an error with a segmentation fault.
The fix in this PR removes `(REACH-GOAL)` when received it from `FFHA` planner.
(I assume action which is named "REACH-GOAL" is rarely defined) 