### PR TITLE
task_compiler: add option exit_on_finish

### DIFF
--- a/task_compiler/launch/execute-pddl.launch
+++ b/task_compiler/launch/execute-pddl.launch
@@ -10,6 +10,7 @@
   <arg name="debug" default="false" doc="enable debug on planning"  />
   <arg name="iterate" default="false" doc="ask y or n for each action execution" />
   <arg name="gui" default="true" doc="run viewer" />
+  <arg name="exit_on_finish" default="true" doc="exit on the end of task performance if enabled"/>
 
   <include file="$(find pddl_planner)/launch/pddl_$(arg planner).launch">
     <arg name="planner_option" value="$(arg planner_option)" if="$(arg use_planner_option)" />
@@ -18,6 +19,7 @@
         if="$(arg gui)" />
   <node name="tc_core"
         pkg="task_compiler" type="execute-pddl.l"
+        required="$(arg exit_on_finish)"
         output="screen" >
     <rosparam subst_value="true">
       action_file: $(arg action)

--- a/task_compiler/test/execute-pddl.test.xml
+++ b/task_compiler/test/execute-pddl.test.xml
@@ -4,6 +4,7 @@
     <arg name="description" value="null"/>
     <arg name="planner_option" value="null"/>
     <arg name="gui" value="false"/>
+    <arg name="exit_on_finish" value="false"/>
   </include>
 </launch>
 

--- a/task_compiler/test/test_task_compiler.test
+++ b/task_compiler/test/test_task_compiler.test
@@ -8,6 +8,7 @@
     <arg name="debug" value="true" />
     <arg name="iterate" value="false" />
     <arg name="gui" value="false" />
+    <arg name="exit_on_finish" value="false"/>
   </include>
 
   <test test-name="test_task_compiler" pkg="roseus" type="roseus"


### PR DESCRIPTION
Continues from https://github.com/jsk-ros-pkg/jsk_planning/pull/58
This PR adds `exit_on_finish` argument to `execute-pddl.launch`.
Without this option enabled, all launch files does not finish automatically on the end of task performance.
This behavior does not match with, for example, `app_manager`.