### PR TITLE
[pddl_planner/demos/2013_fridge_demo] fix bug

### DIFF
--- a/pddl/pddl_planner/demos/2013_fridge_demo/solve-bring-can.l
+++ b/pddl/pddl_planner/demos/2013_fridge_demo/solve-bring-can.l
@@ -54,29 +54,15 @@
                  :effect '((ONHAND ?OBJ)))
 
        (instance pddl-action :init
-                 :name "grasp_f"
-                 :parameters '((?OBJ object))
-                 :precondition '((NOT (ONHAND ?OBJ))
-                                 (NOT (CLOSED))
-                                 (AT PREGRASP))
-                 :effect '())
-
-       (instance pddl-action :init
                  :name "move-to"
                  :parameters '((?FROM ?TO spot))
                  :precondition '((AT ?FROM)
                                  (NOT (= ?FROM SOMEWHERE))
+                                 (NOT (= ?TO SOMEWHERE))
                                  (NOT (= ?FROM ?TO)))
                  :effect '((AT ?TO)
                            (NOT (AT ?FROM))))
-       (instance pddl-action :init
-                 :name "move-to_f"
-                 :parameters '((?FROM ?TO spot))
-                 :precondition '((AT ?FROM)
-                                 (NOT (= ?TO SOMEWHERE))
-                                 (NOT (= ?FROM ?TO)))
-                 :effect '((AT SOMEWHERE)
-                           (NOT (AT ?FROM))))
+
        (instance pddl-action :init
                  :name "move-recoverly"
                  :parameters '()
@@ -84,13 +70,6 @@
                                  (CLOSED))
                  :effect '((AT FRONTFRIDGE)
                            (NOT (AT SOMEWHERE))))
-
-       (instance pddl-action :init
-                 :name "move_rec_f"
-                 :parameters '()
-                 :precondition '((AT SOMEWHERE)
-                                 (CLOSED))
-                 :effect '())
 
        (instance pddl-action :init
                  :name "open-door"
@@ -101,14 +80,6 @@
                  :effect '((NOT (CLOSED))))
 
        (instance pddl-action :init
-                 :name "open_f"
-                 :parameters '()
-                 :precondition '((AT FRONTFRIDGE)
-                                 (NOT (ONHAND CAN))
-                                 (CLOSED))
-                 :effect '())
-
-       (instance pddl-action :init
                  :name "close-door"
                  :parameters '()
                  :precondition '((NOT (CLOSED))
@@ -116,25 +87,11 @@
                  :effect '((CLOSED)))
 
        (instance pddl-action :init
-                 :name "close_f"
-                 :parameters '()
-                 :precondition '((NOT (CLOSED))
-                                 (AT PRECLOSE))
-                 :effect '())
-
-       (instance pddl-action :init
                  :name "try-close"
                  :parameters '()
                  :precondition '((NOT (CLOSED))
                                  (AT SOMEWHERE))
                  :effect '((CLOSED)))
-
-       (instance pddl-action :init
-                 :name "close_try_f"
-                 :parameters '()
-                 :precondition '((NOT (CLOSED))
-                                 (AT SOMEWHERE))
-                 :effect '())
 
        ))
 ;;add action to domain
@@ -144,7 +101,57 @@
 ;;
 ;; solve planning
 ;;
-(setq *failed-nodes* (list 'move-to))
+(setq *failed-nodes*
+      (list
+       (list 'move-to
+             (instance pddl-action :init
+                       :name "move-to_f"
+                       :parameters '((?FROM ?TO spot))
+                       :precondition '((AT ?FROM)
+                                       (NOT (= ?FROM SOMEWHERE))
+                                       (NOT (= ?TO SOMEWHERE))
+                                       (NOT (= ?FROM ?TO)))
+                       :effect '((AT SOMEWHERE)
+                                 (NOT (AT ?FROM)))))
+       (list 'grasp-object
+             (instance pddl-action :init
+                       :name "grasp_f"
+                       :parameters '((?OBJ object))
+                       :precondition '((NOT (ONHAND ?OBJ))
+                                 (NOT (CLOSED))
+                                       (AT PREGRASP))
+                       :effect '()))
+       (list 'move-recoverly
+             (instance pddl-action :init
+                       :name "move_rec_f"
+                       :parameters '()
+                       :precondition '((AT SOMEWHERE)
+                                       (CLOSED))
+                       :effect '()))
+       (list 'open-door
+             (instance pddl-action :init
+                       :name "open_f"
+                       :parameters '()
+                       :precondition '((AT FRONTFRIDGE)
+                                       (NOT (ONHAND CAN))
+                                       (CLOSED))
+                       :effect '()))
+
+       (list 'close-door
+             (instance pddl-action :init
+                       :name "close_f"
+                       :parameters '()
+                       :precondition '((NOT (CLOSED))
+                                       (AT PRECLOSE))
+                       :effect '()))
+       (list 'try-close
+             (instance pddl-action :init
+                       :name "close_try_f"
+                       :parameters '()
+                       :precondition '((NOT (CLOSED))
+                                       (AT SOMEWHERE))
+                       :effect '()))
+      ))
 (setq *graph*
       (pddl-plan-to-graph nil :domain *domain* :problem *problem* :failed-nodes *failed-nodes* :debug t))
 (pprint *result*)

--- a/pddl/pddl_planner/src/eus-pddl.l
+++ b/pddl/pddl_planner/src/eus-pddl.l
@@ -594,13 +594,17 @@
       ))
 
   (:check-condition (st act)
-    (let ((action (find-if #'(lambda (x)
-                               (equal
-                                (or
-                                 (and (send self :use-durative-action)
-                                      (caaddr act))
-                                 (car act))
-                                (intern (string-upcase (send x :name))))) (send domain :action)))
+    (let ((action (if (and (not (atom (car act)))
+                           (not (send self :use-durative-action))
+                           (derivedp (caar act) pddl-action))
+                      (caar act)
+                      (find-if #'(lambda (x)
+                                   (equal
+                                    (or
+                                     (and (send self :use-durative-action)
+                                          (caaddr act))
+                                     (car act))
+                                    (intern (string-upcase (send x :name))))) (send domain :action))))
           param pcond)
       (unless action
         (return-from :check-condition nil))
@@ -707,13 +711,17 @@
       ))
   (:apply-action (st act)
     (if (send self :check-condition st act)
-        (let ((action (find-if #'(lambda (x)
-                                   (equal
-                                    (or
-                                     (and (send self :use-durative-action)
-                                          (caaddr act))
-                                     (car act))
-                                    (intern (string-upcase (send x :name))))) (send domain :action)))
+        (let ((action (if (and (not (atom (car act)))
+                               (not (send self :use-durative-action))
+                               (derivedp (caar act) pddl-action))
+                          (caar act)
+                          (find-if #'(lambda (x)
+                                       (equal
+                                        (or
+                                         (and (send self :use-durative-action)
+                                              (caaddr act))
+                                         (car act))
+                                        (intern (string-upcase (send x :name))))) (send domain :action))))
               param effect (tmp-st st))
           (unless action
             (return-from :apply-action nil))


### PR DESCRIPTION
I fixed two bugs in 2013_fridge_demo.

1. mismatch precondition
`move-to`
https://github.com/jsk-ros-pkg/jsk_planning/blob/b99d2a2e27451ae3acb27d11efdd1712977da446/pddl/pddl_planner/demos/2013_fridge_demo/solve-bring-can.l#L67-L69
`move-to_f`
https://github.com/jsk-ros-pkg/jsk_planning/blob/b99d2a2e27451ae3acb27d11efdd1712977da446/pddl/pddl_planner/demos/2013_fridge_demo/solve-bring-can.l#L75-L77

2. The planner intentionally uses the **failure** action in the main plan.

The planner exploits the following actions to close door in the main plan.
```
(move-to_f hoge fuga)
(try-close)
(move-recoverly)
(move-to FRONTFRIDGE START)
```
This PR removed failure actions from domain while keeping error recovery.