### PR TITLE
use xdg-open instead of gnome-open

### DIFF
--- a/task_compiler/euslisp/execute-pddl-core.l
+++ b/task_compiler/euslisp/execute-pddl-core.l
@@ -47,7 +47,7 @@
     (ros::ros-info "output result to /tmp/action_graph.pdf")
 
     (when display-graph
-      (piped-fork "gnome-open /tmp/action_graph.pdf"))
+      (piped-fork "xdg-open /tmp/action_graph.pdf"))
 
     (setq *sm* (convert-smach graph
                 :return-success return-success :return-fail return-fail

--- a/task_compiler/samples/clean_planning/si11_pddl.l
+++ b/task_compiler/samples/clean_planning/si11_pddl.l
@@ -176,7 +176,7 @@
 
 (send (make-readable-graph *graph*) :write-to-pdf "knock_demo.pdf")
 ;(when (ros::get-param "~display_graph")
-  (piped-fork "gnome-open knock_demo.pdf")
+  (piped-fork "xdg-open knock_demo.pdf")
 ;)
 
 ;; action definition

--- a/task_compiler/samples/failure-recovery-sample/solve-failure-recovery-task.l
+++ b/task_compiler/samples/failure-recovery-sample/solve-failure-recovery-task.l
@@ -118,7 +118,7 @@
   (setq *graph* (make-readable-graph *graph*))
   (send *graph* :write-to-pdf "action_graph.pdf")
   (when (ros::get-param "~display_graph")
-    (piped-fork "gnome-open action_graph.pdf"))
+    (piped-fork "xdg-open action_graph.pdf"))
 
   ;; action definition
   ;; domain -> package


### PR DESCRIPTION
we use `xdg-open` instead of `gnome-open` in task_compiler