### PR TITLE
[Waiting for upstream] use :add-neighbor-from-to in pddl-result-graph.l

### DIFF
--- a/pddl/pddl_planner/src/pddl-result-graph.l
+++ b/pddl/pddl_planner/src/pddl-result-graph.l
@@ -47,7 +47,7 @@
                                    (string-equal (car x) name)))
                 (send from :neighbor-action-alist))
        (warn ";; same arc found ~A~%" name)
-     (send from :add-neighbor to name)))
+     (send self :add-neighbor-from-to from to name)))
   (:write-to-dot ;; redefine for adding arc name
    (fname &optional result-path (title "output"))
     (let ((node-alist  ; ((node . symbol) (node . symbol) ...)


### PR DESCRIPTION
waiting for upstream: https://github.com/euslisp/jskeus/pull/605

we should use `:add-neighbor-from-to` instead of `:add-neighbor`.

This is because `:add-neighbor` adds `arc`, which is not suitable for `pddl-graph`.
`pddl-graph` inherits `costed-graph`, so all arcs should be `costed-arc`.
This PR changes to use `:add-neighbor-from-to`, which adds `costed-arc` (not `arc`) between `from` and `to`.