### PR TITLE
add test to check #92

### DIFF
--- a/pddl/pddl_planner/src/pddl-result-graph.l
+++ b/pddl/pddl_planner/src/pddl-result-graph.l
@@ -47,7 +47,9 @@
                                    (string-equal (car x) name)))
                 (send from :neighbor-action-alist))
        (warn ";; same arc found ~A~%" name)
-     (send from :add-neighbor to name)))
+     (let ((a (send-super :add-arc-from-to from to)))
+       (send a :name name)
+       (send from :neighbors))))
   (:write-to-dot ;; redefine for adding arc name
    (fname &optional result-path (title "output"))
     (let ((node-alist  ; ((node . symbol) (node . symbol) ...)

--- a/pddl/pddl_planner/test/solve-graph-search.l
+++ b/pddl/pddl_planner/test/solve-graph-search.l
@@ -1,0 +1,110 @@
+#!/usr/bin/env roseus
+;; simplified version of pddl_planner/demos/hanoi/solve-hanoi.l
+
+(load "package://pddl_planner/src/pddl-result-graph.l")
+(load "package://pddl_planner/src/eus-pddl-client.l")
+
+(setq *action-client*
+      (instance ros::simple-action-client :init
+                "pddl_planner" pddl_msgs::PDDLPlannerAction))
+;;
+;; problem
+;;
+;;hanoi tower
+(setq *problem* (instance pddl-problem :init :name 'hanoi :domain 'manip))
+
+;;使用する変数の宣言
+(send *problem* :objects
+      '((disk0 . object)
+        (disk1 . object)
+        (disk2 . object)
+        (pole0 . object)
+        (pole1 . object)
+        (pole2 . object))             ; 簡単のため使う型は一つのみに
+      )                            ; disk0,1,2 pole0,1,2すべてobject型
+
+;;初期条件
+;; disk0 disk1 disk2
+;; pole0 pole1 pole2
+(send *problem* :initial-condition
+      '((on disk0 pole0)
+        (on disk1 pole1)
+        (on disk2 pole2)
+        (can-be-on disk0 disk1)
+        (can-be-on disk1 disk2)
+        (clear disk0)
+        (clear disk1)
+        (clear disk2)))
+
+;;初期条件の追加
+(dolist (dd '(disk0 disk1 disk2))
+  (dolist (pp '(pole0 pole1 pole2))
+    (send *problem* :add :initial-condition
+          (list 'can-be-on dd pp))))
+
+;;終了条件
+;;
+;;             disk0
+;;             disk1
+;;             disk2
+;; pole0 pole1 pole2
+(send *problem* :goal-condition
+      '((on disk0 disk1)
+        (on disk1 disk2)
+        (on disk2 pole2)
+        (clear pole0)
+        (clear pole1)
+        (clear disk0)
+        ))
+
+;;
+;; domain
+;;
+(setq *domain* (instance pddl-domain :init :name 'manip))
+(send *domain* :requirements '(:typing))
+(send *domain* :types '(object))
+(send *domain* :predicates '((on ?obj0 ?obj1 - object)
+                             (clear ?obj - object)
+                             (can-be-on ?obj0 ?obj1 - object)))
+;;making action
+(setq *move* (instance pddl-action :init
+                       :name "move"
+                       :parameters '((?obj ?from ?to object))
+                       :precondition '((clear ?obj)
+                                       (clear ?to)
+                                       (on ?obj ?from)
+                                       (can-be-on ?obj ?to))
+                       :effect '((on ?obj ?to)
+                                 (not (on ?obj ?from))
+                                 (not (clear ?to))
+                                 (clear ?from))))
+;;add action to domain
+(send *domain* :add :action *move*)
+
+
+;;
+;; solve planning
+;;
+(pprint (setq *result* (solve-pddl-planning *domain* *problem*)))
+(setq *gr* (make-graph-from-pddl-results (list *result*) :node-name :pprint))
+
+(require :unittest "lib/llib/unittest.l")
+(init-unit-test)
+
+(deftest test-graph-solve ()
+  (let (solver path result-path solved-path)
+    ;; solve graph search
+    (send *gr* :start-state (elt (send *gr* :nodes) 2))
+    (send *gr* :goal-state  (elt (send *gr* :nodes) 0))
+    (setq solver (instance breadth-first-graph-search-solver :init))
+    (setq path (send solver :solve *gr* :verbose nil))
+
+    (setq result-path (cdr (assoc :plan *result*)))
+    (setq solved-path (mapcar #'read-from-string (cdr (send-all (send-all path :action) :name))))
+    (format *error-output* "result-path ~A~%" result-path)
+    (format *error-output* "solved-path ~A~%" solved-path)
+    (assert (equal solved-path result-path))
+    ))
+
+(run-all-tests)
+(exit)

--- a/pddl/pddl_planner/test/test-sample-pddl.test
+++ b/pddl/pddl_planner/test/test-sample-pddl.test
@@ -23,4 +23,9 @@
   <test test-name="sample_pddl_downward_client" pkg="pddl_planner" type="sample-client.py" >
     <remap from="pddl_planner" to="downward_planner/pddl_planner" />
   </test>
+  <!--
+  Test program to solve as graph search (https://github.com/jsk-ros-pkg/jsk_planning/pull/92)
+  -->
+  <test test-name="solve_graph_search" pkg="pddl_planner"
+        type="solve-graph-search.l" ns="ffha_planner" />
 </launch>


### PR DESCRIPTION
cannot run graph-solver for pddl-graph

see #92 for detail

use `:add-arc-from-to` instead of `:add-neighbor`, which is obsoleted methods

https://github.com/euslisp/jskeus/blob/89932980fe64eb0c0db6dbe6b79b61e2d3d17169/irteus/irtgraph.l#L379-L382

cc: @Kanazawanaoaki  